### PR TITLE
Fix pagination response

### DIFF
--- a/scripts/generateGraphQLDocs.js
+++ b/scripts/generateGraphQLDocs.js
@@ -98,10 +98,14 @@ query {
 function generateQueryVariables(parameters) {
     let variables = {};
     parameters.forEach(param => {
-        variables[param.name] = param.defaultValue ??
+        let value = param.defaultValue ??
             (param.type.includes("Int") ? 1 :
                 param.type.includes("Boolean") ? true :
                     param.name.toLowerCase() === "id" ? "pid_graph:Sample_Value" : "sample_value");
+
+        if (typeof value === 'string') { value = value.replace(/,+$/, '').trim(); }
+        variables[param.name] = value;
+
     });
     return variables;
 }


### PR DESCRIPTION
### Problem:

- There was an issue with the pagination functionality where the page parameter was incorrectly handled as 1, (with a trailing comma), preventing the correct response from being returned.

### Changes:
- Pagination Fix: The page value was cleaned by removing any trailing commas and spaces (1, was changed to 1), ensuring proper pagination functionality.

